### PR TITLE
Feature/#3 GitHub authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ xcuserdata/
 
 # End of https://www.toptal.com/developers/gitignore/api/xcode,macos,swiftpackagemanager,cocoapods
 
+
+LabelLab/LabelLab/Utilities/KeyStorage.swift

--- a/LabelLab/LabelLab.xcodeproj/project.pbxproj
+++ b/LabelLab/LabelLab.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		00A79A342886DD6C006D5DCD /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 00A79A332886DD6C006D5DCD /* FirebaseFirestore */; };
 		00A79A362886DD6C006D5DCD /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 00A79A352886DD6C006D5DCD /* FirebaseFirestoreSwift */; };
 		00F8F10728B4785A00D688AC /* KeyStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F8F10628B4785A00D688AC /* KeyStorage.swift */; };
+		00F8F10A28B4798D00D688AC /* OAuthAuthenticatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F8F10928B4798D00D688AC /* OAuthAuthenticatorTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,6 +76,7 @@
 		00A79A2E2886DC48006D5DCD /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		00F8F10528B475CD00D688AC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		00F8F10628B4785A00D688AC /* KeyStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyStorage.swift; sourceTree = "<group>"; };
+		00F8F10928B4798D00D688AC /* OAuthAuthenticatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthAuthenticatorTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -145,6 +147,7 @@
 		002789962885986F00BDCDA4 /* LabelLabTests */ = {
 			isa = PBXGroup;
 			children = (
+				00F8F10828B4796500D688AC /* Authentication */,
 				002789972885986F00BDCDA4 /* LabelLabTests.swift */,
 			);
 			path = LabelLabTests;
@@ -238,6 +241,14 @@
 				002789872885986D00BDCDA4 /* ContentView.swift */,
 			);
 			path = Screens;
+			sourceTree = "<group>";
+		};
+		00F8F10828B4796500D688AC /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				00F8F10928B4798D00D688AC /* OAuthAuthenticatorTest.swift */,
+			);
+			path = Authentication;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -401,6 +412,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				002789982885986F00BDCDA4 /* LabelLabTests.swift in Sources */,
+				00F8F10A28B4798D00D688AC /* OAuthAuthenticatorTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LabelLab/LabelLab.xcodeproj/project.pbxproj
+++ b/LabelLab/LabelLab.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		00A79A322886DD6C006D5DCD /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 00A79A312886DD6C006D5DCD /* FirebaseAuth */; };
 		00A79A342886DD6C006D5DCD /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 00A79A332886DD6C006D5DCD /* FirebaseFirestore */; };
 		00A79A362886DD6C006D5DCD /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 00A79A352886DD6C006D5DCD /* FirebaseFirestoreSwift */; };
+		00F8F10728B4785A00D688AC /* KeyStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F8F10628B4785A00D688AC /* KeyStorage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,6 +73,8 @@
 		00674C9F28AF793C00E850B7 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		00674CA128AF7D4700E850B7 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
 		00A79A2E2886DC48006D5DCD /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		00F8F10528B475CD00D688AC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		00F8F10628B4785A00D688AC /* KeyStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyStorage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -126,6 +129,7 @@
 		002789842885986D00BDCDA4 /* LabelLab */ = {
 			isa = PBXGroup;
 			children = (
+				00F8F10528B475CD00D688AC /* Info.plist */,
 				002789B2288598AF00BDCDA4 /* Injected */,
 				002789B4288598C400BDCDA4 /* Interactors */,
 				002789B5288598CC00BDCDA4 /* Models */,
@@ -170,6 +174,7 @@
 				0037AD9F28AE41EE000C36AC /* Helpers.swift */,
 				0037ADA328AE4555000C36AC /* Loadable.swift */,
 				0037ADA528AE47CB000C36AC /* AuthenticationRequiredLoadable.swift */,
+				00F8F10628B4785A00D688AC /* KeyStorage.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -379,6 +384,7 @@
 				0037AD9E28AE3CCB000C36AC /* DIContainer.swift in Sources */,
 				00674CA228AF7D4700E850B7 /* MockData.swift in Sources */,
 				0037ADA828AE5789000C36AC /* Template.swift in Sources */,
+				00F8F10728B4785A00D688AC /* KeyStorage.swift in Sources */,
 				0037ADAC28AE57A4000C36AC /* Label.swift in Sources */,
 				00674CA028AF793C00E850B7 /* Color.swift in Sources */,
 				0037AD9C28AE3AE4000C36AC /* AppState.swift in Sources */,
@@ -549,6 +555,7 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LabelLab/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -576,6 +583,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"LabelLab/Resources";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LabelLab/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/LabelLab/LabelLab.xcodeproj/project.pbxproj
+++ b/LabelLab/LabelLab.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		00A79A362886DD6C006D5DCD /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 00A79A352886DD6C006D5DCD /* FirebaseFirestoreSwift */; };
 		00F8F10728B4785A00D688AC /* KeyStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F8F10628B4785A00D688AC /* KeyStorage.swift */; };
 		00F8F10A28B4798D00D688AC /* OAuthAuthenticatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F8F10928B4798D00D688AC /* OAuthAuthenticatorTest.swift */; };
+		00F8F10D28B47AC200D688AC /* OAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F8F10C28B47AC200D688AC /* OAuthService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,6 +78,7 @@
 		00F8F10528B475CD00D688AC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		00F8F10628B4785A00D688AC /* KeyStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyStorage.swift; sourceTree = "<group>"; };
 		00F8F10928B4798D00D688AC /* OAuthAuthenticatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthAuthenticatorTest.swift; sourceTree = "<group>"; };
+		00F8F10C28B47AC200D688AC /* OAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,6 +133,7 @@
 		002789842885986D00BDCDA4 /* LabelLab */ = {
 			isa = PBXGroup;
 			children = (
+				00F8F10B28B47AB700D688AC /* Service */,
 				00F8F10528B475CD00D688AC /* Info.plist */,
 				002789B2288598AF00BDCDA4 /* Injected */,
 				002789B4288598C400BDCDA4 /* Interactors */,
@@ -249,6 +252,14 @@
 				00F8F10928B4798D00D688AC /* OAuthAuthenticatorTest.swift */,
 			);
 			path = Authentication;
+			sourceTree = "<group>";
+		};
+		00F8F10B28B47AB700D688AC /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				00F8F10C28B47AC200D688AC /* OAuthService.swift */,
+			);
+			path = Service;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -402,6 +413,7 @@
 				0037ADA628AE47CB000C36AC /* AuthenticationRequiredLoadable.swift in Sources */,
 				002789882885986D00BDCDA4 /* ContentView.swift in Sources */,
 				0037ADA028AE41EE000C36AC /* Helpers.swift in Sources */,
+				00F8F10D28B47AC200D688AC /* OAuthService.swift in Sources */,
 				0037ADAA28AE579E000C36AC /* UserInfo.swift in Sources */,
 				002789862885986D00BDCDA4 /* LabelLabApp.swift in Sources */,
 			);
@@ -619,7 +631,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = team.leejongwoo.LabelLabTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -637,7 +649,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = team.leejongwoo.LabelLabTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/LabelLab/LabelLab.xcodeproj/project.pbxproj
+++ b/LabelLab/LabelLab.xcodeproj/project.pbxproj
@@ -32,6 +32,9 @@
 		00F8F10728B4785A00D688AC /* KeyStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F8F10628B4785A00D688AC /* KeyStorage.swift */; };
 		00F8F10A28B4798D00D688AC /* OAuthAuthenticatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F8F10928B4798D00D688AC /* OAuthAuthenticatorTest.swift */; };
 		00F8F10D28B47AC200D688AC /* OAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F8F10C28B47AC200D688AC /* OAuthService.swift */; };
+		00F8F10F28B49E6300D688AC /* APICall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F8F10E28B49E6300D688AC /* APICall.swift */; };
+		00F8F11228B4A0A500D688AC /* GithubAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F8F11128B4A0A500D688AC /* GithubAPI.swift */; };
+		00F8F11428B4A1A200D688AC /* URLCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F8F11328B4A1A200D688AC /* URLCollection.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +82,9 @@
 		00F8F10628B4785A00D688AC /* KeyStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyStorage.swift; sourceTree = "<group>"; };
 		00F8F10928B4798D00D688AC /* OAuthAuthenticatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthAuthenticatorTest.swift; sourceTree = "<group>"; };
 		00F8F10C28B47AC200D688AC /* OAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthService.swift; sourceTree = "<group>"; };
+		00F8F10E28B49E6300D688AC /* APICall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICall.swift; sourceTree = "<group>"; };
+		00F8F11128B4A0A500D688AC /* GithubAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubAPI.swift; sourceTree = "<group>"; };
+		00F8F11328B4A1A200D688AC /* URLCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLCollection.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -181,6 +187,7 @@
 				0037ADA328AE4555000C36AC /* Loadable.swift */,
 				0037ADA528AE47CB000C36AC /* AuthenticationRequiredLoadable.swift */,
 				00F8F10628B4785A00D688AC /* KeyStorage.swift */,
+				00F8F11328B4A1A200D688AC /* URLCollection.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -257,9 +264,19 @@
 		00F8F10B28B47AB700D688AC /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				00F8F11028B4A09300D688AC /* API */,
 				00F8F10C28B47AC200D688AC /* OAuthService.swift */,
 			);
 			path = Service;
+			sourceTree = "<group>";
+		};
+		00F8F11028B4A09300D688AC /* API */ = {
+			isa = PBXGroup;
+			children = (
+				00F8F10E28B49E6300D688AC /* APICall.swift */,
+				00F8F11128B4A0A500D688AC /* GithubAPI.swift */,
+			);
+			path = API;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -411,11 +428,14 @@
 				00674CA028AF793C00E850B7 /* Color.swift in Sources */,
 				0037AD9C28AE3AE4000C36AC /* AppState.swift in Sources */,
 				0037ADA628AE47CB000C36AC /* AuthenticationRequiredLoadable.swift in Sources */,
+				00F8F11228B4A0A500D688AC /* GithubAPI.swift in Sources */,
 				002789882885986D00BDCDA4 /* ContentView.swift in Sources */,
 				0037ADA028AE41EE000C36AC /* Helpers.swift in Sources */,
 				00F8F10D28B47AC200D688AC /* OAuthService.swift in Sources */,
 				0037ADAA28AE579E000C36AC /* UserInfo.swift in Sources */,
+				00F8F10F28B49E6300D688AC /* APICall.swift in Sources */,
 				002789862885986D00BDCDA4 /* LabelLabApp.swift in Sources */,
+				00F8F11428B4A1A200D688AC /* URLCollection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LabelLab/LabelLab.xcodeproj/xcshareddata/xcschemes/LabelLabTest.xcscheme
+++ b/LabelLab/LabelLab.xcodeproj/xcshareddata/xcschemes/LabelLabTest.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "002789812885986D00BDCDA4"
+               BuildableName = "LabelLab.app"
+               BlueprintName = "LabelLab"
+               ReferencedContainer = "container:LabelLab.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "002789922885986F00BDCDA4"
+               BuildableName = "LabelLabTests.xctest"
+               BlueprintName = "LabelLabTests"
+               ReferencedContainer = "container:LabelLab.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "002789922885986F00BDCDA4"
+               BuildableName = "LabelLabTests.xctest"
+               BlueprintName = "LabelLabTests"
+               ReferencedContainer = "container:LabelLab.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "002789812885986D00BDCDA4"
+            BuildableName = "LabelLab.app"
+            BlueprintName = "LabelLab"
+            ReferencedContainer = "container:LabelLab.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "002789812885986D00BDCDA4"
+            BuildableName = "LabelLab.app"
+            BlueprintName = "LabelLab"
+            ReferencedContainer = "container:LabelLab.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LabelLab/LabelLab/Info.plist
+++ b/LabelLab/LabelLab/Info.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>team.leejongwoo.LabelLab</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>labellab</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/LabelLab/LabelLab/Service/API/APICall.swift
+++ b/LabelLab/LabelLab/Service/API/APICall.swift
@@ -1,0 +1,34 @@
+//
+//  APICall.swift
+//  LabelLab
+//
+//  Created by JongHo Park on 2022/08/23.
+//
+
+import Foundation
+
+typealias Headers = [String: String]
+typealias Parameters = [String: String]
+
+protocol APICall {
+    var path: String { get }
+    var method: String { get }
+    var headers: Headers { get }
+    var parameters: Parameters { get }
+    var baseURL: String { get }
+}
+
+extension APICall {
+
+    var url: URL? {
+        let urlComponents: URLComponents? = URLComponents(string: baseURL + path)
+        guard var urlComponents = urlComponents else { return nil }
+        var queryItems: [URLQueryItem] = []
+        for (key, value) in parameters {
+            queryItems.append(URLQueryItem(name: key, value: value))
+        }
+        urlComponents.queryItems = queryItems
+        return urlComponents.url
+    }
+
+}

--- a/LabelLab/LabelLab/Service/API/GithubAPI.swift
+++ b/LabelLab/LabelLab/Service/API/GithubAPI.swift
@@ -1,0 +1,51 @@
+//
+//  GithubAPI.swift
+//  LabelLab
+//
+//  Created by JongHo Park on 2022/08/23.
+//
+
+import Foundation
+
+enum GithubAPI {
+    case authorize
+}
+
+extension GithubAPI: APICall {
+
+    var path: String {
+        switch self {
+        case .authorize:
+            return URLCollection.Github.GITHUB_AUTHORIZE
+        }
+    }
+
+    var method: String {
+        switch self {
+        case .authorize: return "get"
+        }
+    }
+
+    var headers: Headers {
+        switch self {
+        case .authorize:
+            return [:]
+        }
+    }
+
+    var parameters: Parameters {
+        switch self {
+        case .authorize:
+            return ["client_id": KeyStorage.GithubClientId,
+                    "scope": "user, repo"]
+        }
+    }
+
+    var baseURL: String {
+        switch self {
+        case .authorize:
+            return URLCollection.Github.GITHUB_AUTHENTICATE_BASE_URL
+        }
+    }
+
+}

--- a/LabelLab/LabelLab/Service/OAuthService.swift
+++ b/LabelLab/LabelLab/Service/OAuthService.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import AppKit
 
 protocol OAuthService {
     func openOAuthSite()
@@ -15,19 +14,17 @@ protocol OAuthService {
 final class GithubOAuthService {
     static let shared: GithubOAuthService = .init()
 
-    private var oAuthSiteURL: String {
-        "https://github.com/login/oauth/authorize?client_id=\(KeyStorage.GithubClientId)&scope=user,repo"
-    }
-
     private init() {}
 }
 
+#if canImport(AppKit)
+
+import AppKit
+
 extension GithubOAuthService: OAuthService {
     func openOAuthSite() {
-        guard let url = URL(string: oAuthSiteURL) else { return }
-        #if os(macOS)
+        guard let url = GithubAPI.authorize.url else { return }
         NSWorkspace.shared.open(url)
-        #endif
     }
 }
-
+#endif

--- a/LabelLab/LabelLab/Service/OAuthService.swift
+++ b/LabelLab/LabelLab/Service/OAuthService.swift
@@ -1,0 +1,33 @@
+//
+//  OAuthService.swift
+//  LabelLab
+//
+//  Created by JongHo Park on 2022/08/23.
+//
+
+import Foundation
+import AppKit
+
+protocol OAuthService {
+    func openOAuthSite()
+}
+
+final class GithubOAuthService {
+    static let shared: GithubOAuthService = .init()
+
+    private var oAuthSiteURL: String {
+        "https://github.com/login/oauth/authorize?client_id=\(KeyStorage.GithubClientId)&scope=user,repo"
+    }
+
+    private init() {}
+}
+
+extension GithubOAuthService: OAuthService {
+    func openOAuthSite() {
+        guard let url = URL(string: oAuthSiteURL) else { return }
+        #if os(macOS)
+        NSWorkspace.shared.open(url)
+        #endif
+    }
+}
+

--- a/LabelLab/LabelLab/Utilities/URLCollection.swift
+++ b/LabelLab/LabelLab/Utilities/URLCollection.swift
@@ -1,0 +1,15 @@
+//
+//  URLCollection.swift
+//  LabelLab
+//
+//  Created by JongHo Park on 2022/08/23.
+//
+
+enum URLCollection {
+    enum Github {
+        static let GITHUB_AUTHENTICATE_BASE_URL: String = "https://github.com/login"
+        static let GITHUB_AUTHORIZE: String = "/oauth/authorize"
+        static let GITHUB_ACCESS_TOKEN: String = "/oauth/access_token"
+    }
+}
+

--- a/LabelLab/LabelLabTests/Authentication/OAuthAuthenticatorTest.swift
+++ b/LabelLab/LabelLabTests/Authentication/OAuthAuthenticatorTest.swift
@@ -1,0 +1,27 @@
+//
+//  OAuthAuthenticatorTest.swift
+//  LabelLabTests
+//
+//  Created by JongHo Park on 2022/08/23.
+//
+
+@testable import LabelLab
+import XCTest
+
+final class OAuthAuthenticatorTest: XCTestCase {
+
+    private var oAuthService: OAuthService!
+    override func setUpWithError() throws {
+        oAuthService = LabelLab.GithubOAuthService()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        oAuthService = nil
+    }
+
+    func testOpenOAuthSite() throws {
+        oAuthService.openOAuthSite()
+    }
+
+}

--- a/LabelLab/LabelLabTests/Authentication/OAuthAuthenticatorTest.swift
+++ b/LabelLab/LabelLabTests/Authentication/OAuthAuthenticatorTest.swift
@@ -12,7 +12,7 @@ final class OAuthAuthenticatorTest: XCTestCase {
 
     private var oAuthService: OAuthService!
     override func setUpWithError() throws {
-        oAuthService = LabelLab.GithubOAuthService()
+        oAuthService = GithubOAuthService.shared
     }
 
     override func tearDownWithError() throws {
@@ -22,6 +22,7 @@ final class OAuthAuthenticatorTest: XCTestCase {
 
     func testOpenOAuthSite() throws {
         oAuthService.openOAuthSite()
+        XCTAssert(true)
     }
 
 }


### PR DESCRIPTION
# Issue Number
🔒 Close #3

## New features

- Open Github site and request oAuth request code

## Review points

- [APICall Protocol 화 및 APICall 을 준수하는 Github API](https://github.com/HoJongE/LabelLab/compare/develop...HoJongE:feature%2F%233_github_authorization?expand=1#diff-ddc5edfad31ade1efbe91b891e1412542b4d64586cfce8fe7a399d470f0b338cR13-R19)
- [OAuthService 프로토콜](https://github.com/HoJongE/LabelLab/compare/develop...HoJongE:feature%2F%233_github_authorization?expand=1#diff-ddc5edfad31ade1efbe91b891e1412542b4d64586cfce8fe7a399d470f0b338cR13-R19)

## Questions

- Github API 사용에 필요한 Client id 와 Client secret 을 보관하는 방법으로, KeyStorage.swift 파일을 생성해 gitignore 에 추가하는 방식을 선택했습니다. 일단 지금은 빌드 테스트를 진행하지 않으므로 ignore  로 swift 파일을 무시하더라도 상관없을 것 같습니다. 더 나은 민감 정보 보호 방법을 알고 계시다면 추천해주세요!

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
