### PR TITLE
Feat: Add Authorize Popup UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ xcuserdata/
 
 
 LabelLab/LabelLab/Utilities/KeyStorage.swift
+
+*.xcscheme

--- a/LabelLab/LabelLab.xcodeproj/project.pbxproj
+++ b/LabelLab/LabelLab.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		002789982885986F00BDCDA4 /* LabelLabTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002789972885986F00BDCDA4 /* LabelLabTests.swift */; };
 		002789A22885986F00BDCDA4 /* LabelLabUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002789A12885986F00BDCDA4 /* LabelLabUITests.swift */; };
 		002789A42885986F00BDCDA4 /* LabelLabUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002789A32885986F00BDCDA4 /* LabelLabUITestsLaunchTests.swift */; };
+		0036D21F28B5BDF200A08479 /* DismissButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0036D21E28B5BDF200A08479 /* DismissButton.swift */; };
 		0037AD9C28AE3AE4000C36AC /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0037AD9B28AE3AE4000C36AC /* AppState.swift */; };
 		0037AD9E28AE3CCB000C36AC /* DIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0037AD9D28AE3CCB000C36AC /* DIContainer.swift */; };
 		0037ADA028AE41EE000C36AC /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0037AD9F28AE41EE000C36AC /* Helpers.swift */; };
@@ -23,6 +24,7 @@
 		0037ADA828AE5789000C36AC /* Template.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0037ADA728AE5789000C36AC /* Template.swift */; };
 		0037ADAA28AE579E000C36AC /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0037ADA928AE579E000C36AC /* UserInfo.swift */; };
 		0037ADAC28AE57A4000C36AC /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0037ADAB28AE57A4000C36AC /* Label.swift */; };
+		0038C29F28B50976009C98E2 /* AuthorizePopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0038C29E28B50976009C98E2 /* AuthorizePopup.swift */; };
 		00674CA028AF793C00E850B7 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00674C9F28AF793C00E850B7 /* Color.swift */; };
 		00674CA228AF7D4700E850B7 /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00674CA128AF7D4700E850B7 /* MockData.swift */; };
 		00A79A2F2886DC48006D5DCD /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 00A79A2E2886DC48006D5DCD /* GoogleService-Info.plist */; };
@@ -66,6 +68,7 @@
 		0027899D2885986F00BDCDA4 /* LabelLabUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LabelLabUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		002789A12885986F00BDCDA4 /* LabelLabUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelLabUITests.swift; sourceTree = "<group>"; };
 		002789A32885986F00BDCDA4 /* LabelLabUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelLabUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		0036D21E28B5BDF200A08479 /* DismissButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissButton.swift; sourceTree = "<group>"; };
 		0037AD9B28AE3AE4000C36AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		0037AD9D28AE3CCB000C36AC /* DIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIContainer.swift; sourceTree = "<group>"; };
 		0037AD9F28AE41EE000C36AC /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
@@ -75,6 +78,7 @@
 		0037ADA728AE5789000C36AC /* Template.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Template.swift; sourceTree = "<group>"; };
 		0037ADA928AE579E000C36AC /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		0037ADAB28AE57A4000C36AC /* Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
+		0038C29E28B50976009C98E2 /* AuthorizePopup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizePopup.swift; sourceTree = "<group>"; };
 		00674C9F28AF793C00E850B7 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		00674CA128AF7D4700E850B7 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
 		00A79A2E2886DC48006D5DCD /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -230,6 +234,7 @@
 		002789B6288598CE00BDCDA4 /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				0036D21D28B5BDE900A08479 /* Components */,
 				002789B8288598E800BDCDA4 /* Screens */,
 			);
 			path = UI;
@@ -248,9 +253,26 @@
 		002789B8288598E800BDCDA4 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				0038C29D28B5092D009C98E2 /* Authorize */,
 				002789872885986D00BDCDA4 /* ContentView.swift */,
 			);
 			path = Screens;
+			sourceTree = "<group>";
+		};
+		0036D21D28B5BDE900A08479 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				0036D21E28B5BDF200A08479 /* DismissButton.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		0038C29D28B5092D009C98E2 /* Authorize */ = {
+			isa = PBXGroup;
+			children = (
+				0038C29E28B50976009C98E2 /* AuthorizePopup.swift */,
+			);
+			path = Authorize;
 			sourceTree = "<group>";
 		};
 		00F8F10828B4796500D688AC /* Authentication */ = {
@@ -420,6 +442,7 @@
 			files = (
 				0037ADA228AE42E0000C36AC /* Interactors.swift in Sources */,
 				0037ADA428AE4555000C36AC /* Loadable.swift in Sources */,
+				0038C29F28B50976009C98E2 /* AuthorizePopup.swift in Sources */,
 				0037AD9E28AE3CCB000C36AC /* DIContainer.swift in Sources */,
 				00674CA228AF7D4700E850B7 /* MockData.swift in Sources */,
 				0037ADA828AE5789000C36AC /* Template.swift in Sources */,
@@ -435,6 +458,7 @@
 				0037ADAA28AE579E000C36AC /* UserInfo.swift in Sources */,
 				00F8F10F28B49E6300D688AC /* APICall.swift in Sources */,
 				002789862885986D00BDCDA4 /* LabelLabApp.swift in Sources */,
+				0036D21F28B5BDF200A08479 /* DismissButton.swift in Sources */,
 				00F8F11428B4A1A200D688AC /* URLCollection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LabelLab/LabelLab/Injected/AppState.swift
+++ b/LabelLab/LabelLab/Injected/AppState.swift
@@ -8,15 +8,25 @@
 import Foundation
 
 final class AppState: ObservableObject {
-    @Published var userData: UserData = UserData()
-    @Published var routing: ViewRouting = ViewRouting()
+    @Published var userData: UserData
+    @Published var routing: ViewRouting
+
+    init(_ userData: UserData = UserData(), _ routing: ViewRouting = ViewRouting()) {
+        self.userData = userData
+        self.routing = routing
+    }
 }
 
 // MARK: - User data
 extension AppState {
 
     struct UserData {
+        var userInfo: Loadable<UserInfo>
         // for Template List
+
+        init(userInfo: Loadable<UserInfo> = .notRequested) {
+            self.userInfo = userInfo
+        }
     }
 
 }
@@ -25,6 +35,7 @@ extension AppState {
 extension AppState {
 
     struct ViewRouting: Equatable {
+        var rootRouting = ContentView.Routing()
     }
 
 }

--- a/LabelLab/LabelLab/Injected/DIContainer.swift
+++ b/LabelLab/LabelLab/Injected/DIContainer.swift
@@ -53,9 +53,9 @@ extension DIContainer {
 extension View {
 
     @ViewBuilder
-    func injectPreview() -> some View {
-        self.environmentObject(AppState.preview)
-            .environment(\.injected, DIContainer.preview)
+    func injectPreview(_ appState: AppState? = nil, _ diConainter: DIContainer? = nil) -> some View {
+        self.environmentObject(appState ?? AppState.preview)
+            .environment(\.injected, diConainter ?? DIContainer.preview)
     }
 
 }

--- a/LabelLab/LabelLab/UI/Components/DismissButton.swift
+++ b/LabelLab/LabelLab/UI/Components/DismissButton.swift
@@ -1,0 +1,49 @@
+//
+//  DismissButton.swift
+//  LabelLab
+//
+//  Created by JongHo Park on 2022/08/24.
+//
+
+import SwiftUI
+
+struct DismissButton: View {
+    @State private var isHover: Bool = false
+    private let onClick: () -> Void
+
+    init(_ onClick: @escaping () -> Void = {}) {
+        self.onClick = onClick
+    }
+
+    var body: some View {
+        Button {
+            onClick()
+        } label: {
+            Circle()
+                .fill(Color.red)
+                .frame(width: 12)
+                .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
+                .overlay(alignment: .center) {
+                    if isHover {
+                        Text(Image(systemName: "xmark"))
+                            .fontWeight(.black)
+                            .foregroundColor(.black.opacity(0.6))
+                            .font(.system(size: 8))
+                    } else {
+                        EmptyView()
+                    }
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hover in
+            isHover = hover
+        }
+    }
+}
+
+struct DismissButton_Previews: PreviewProvider {
+    static var previews: some View {
+        DismissButton()
+    }
+}

--- a/LabelLab/LabelLab/UI/Components/DismissButton.swift
+++ b/LabelLab/LabelLab/UI/Components/DismissButton.swift
@@ -21,7 +21,7 @@ struct DismissButton: View {
         } label: {
             Circle()
                 .fill(Color.red)
-                .frame(width: 12)
+                .frame(width: 12, height: 12)
                 .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
                 .overlay(alignment: .center) {
                     if isHover {

--- a/LabelLab/LabelLab/UI/Screens/Authorize/AuthorizePopup.swift
+++ b/LabelLab/LabelLab/UI/Screens/Authorize/AuthorizePopup.swift
@@ -9,9 +9,8 @@ import SwiftUI
 
 struct AuthorizePopup: View {
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject private var appState: AppState
     @Environment(\.injected) private var diContainer: DIContainer
-    @State private var isCloseButtonHover: Bool = false
+    @EnvironmentObject private var appState: AppState
 
     var body: some View {
         content()

--- a/LabelLab/LabelLab/UI/Screens/Authorize/AuthorizePopup.swift
+++ b/LabelLab/LabelLab/UI/Screens/Authorize/AuthorizePopup.swift
@@ -168,18 +168,18 @@ private extension AuthorizePopup {
     func errorIndicator(_ error: Error) -> some View {
         VStack {
             HStack {
-                statusTitle
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
+                dismissButton.frame(maxWidth: .infinity, alignment: .leading)
+                statusTitle.frame(maxWidth: .infinity, alignment: .leading)
+                Spacer().frame(maxWidth: .infinity)
             }
             .background(Color.statusBackground)
             Spacer()
             HStack(spacing: 0) {
                 failIcon.padding(.trailing, 22)
-                Text("Error occur when signing in, Please try again").fontWeight(.bold)
+                Text("An Error occur when signing in, Please try again").fontWeight(.bold)
                 Spacer()
             }
-            .padding(.leading, 39)
+            .padding(.leading, 22)
             HStack {
                 Spacer()
                 authorizeButton.padding(.trailing, 33)

--- a/LabelLab/LabelLab/UI/Screens/Authorize/AuthorizePopup.swift
+++ b/LabelLab/LabelLab/UI/Screens/Authorize/AuthorizePopup.swift
@@ -1,0 +1,220 @@
+//
+//  AuthorizePopup.swift
+//  LabelLab
+//
+//  Created by JongHo Park on 2022/08/23.
+//
+
+import SwiftUI
+
+struct AuthorizePopup: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var appState: AppState
+    @Environment(\.injected) private var diContainer: DIContainer
+    @State private var isCloseButtonHover: Bool = false
+
+    var body: some View {
+        content()
+            .frame(width: 439, height: 186, alignment: .topLeading)
+    }
+}
+
+// MARK: - UI Componenets
+private extension AuthorizePopup {
+
+    var statusTitle: some View {
+        Text("Github Accounts")
+            .fontWeight(.bold)
+            .foregroundColor(.statusTitle)
+            .frame(maxWidth: .infinity)
+    }
+
+    var dismissButton: some View {
+        DismissButton {
+            dismiss()
+        }
+    }
+
+    var finishButton: some View {
+        Button {
+            dismiss()
+        } label: {
+            Text("Finish")
+                .fontWeight(.medium)
+                .contentShape(Rectangle())
+                .padding(EdgeInsets(top: 4, leading: 14, bottom: 4, trailing: 14))
+                .background(RoundedRectangle(cornerRadius: 6)
+                    .fill(finishButtonGraident))
+        }
+        .buttonStyle(.plain)
+    }
+
+    var finishButtonGraident: LinearGradient {
+        LinearGradient(colors: [Color("4B91F7"), Color("367AF6")], startPoint: .top, endPoint: .bottom)
+    }
+
+    var authorizeButton: some View {
+        HStack {
+            Spacer()
+            Button(action: authorizeGithub) {
+                Text("Authorize Github")
+            }
+        }
+    }
+}
+
+// MARK: - Side Effects
+private extension AuthorizePopup {
+    func authorizeGithub() {
+        // TODO: Interacts with Interactor
+    }
+}
+
+// MARK: - Content
+private extension AuthorizePopup {
+    @ViewBuilder
+    func content() -> some View {
+        switch appState.userData.userInfo {
+        case .notRequested:
+            notRequested()
+        case .isLoading:
+            loading()
+        case .loaded(let userInfo):
+            loaded(userInfo)
+        case .failed(let error):
+            errorIndicator(error)
+        }
+    }
+}
+
+// MARK: - not requested view
+private extension AuthorizePopup {
+    func notRequested() -> some View {
+        VStack {
+            HStack {
+                dismissButton.frame(maxWidth: .infinity, alignment: .leading)
+                statusTitle.frame(maxWidth: .infinity, alignment: .leading)
+                Spacer().frame(maxWidth: .infinity)
+            }
+            .background(Color.statusBackground)
+            Spacer()
+            Text("Sign in here to make and upload your own labels")
+            Spacer()
+            authorizeButton.padding()
+        }
+    }
+
+}
+
+// MARK: - loading view
+private extension AuthorizePopup {
+
+    func loading() -> some View {
+        VStack {
+            HStack {
+                statusTitle
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
+            }
+            .background(Color.statusBackground)
+
+            Spacer()
+            Text("Requesting Github Access token")
+                .fontWeight(.semibold)
+            ProgressView()
+                .progressViewStyle(.circular)
+
+            Spacer()
+
+        }
+    }
+}
+
+// MARK: - loaded View
+private extension AuthorizePopup {
+    func loaded(_ userInfo: UserInfo) -> some View {
+        VStack {
+            HStack {
+                statusTitle
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
+            }
+            .background(Color.statusBackground)
+            Spacer()
+            HStack(spacing: 0) {
+                successIcon.padding(.trailing, 22)
+                Text("Congratulations, you`re all set!").fontWeight(.bold)
+                Spacer()
+            }
+            .padding(.leading, 39)
+            HStack {
+                Spacer()
+                finishButton.padding(.trailing, 33)
+            }
+            Spacer()
+        }
+    }
+
+    var successIcon: some View {
+        Text(Image(systemName: "checkmark.circle.fill"))
+            .fontWeight(.bold)
+            .foregroundColor(.green)
+            .font(.system(size: 42))
+    }
+
+}
+
+// MARK: - error view
+private extension AuthorizePopup {
+    func errorIndicator(_ error: Error) -> some View {
+        VStack {
+            HStack {
+                statusTitle
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
+            }
+            .background(Color.statusBackground)
+            Spacer()
+            HStack(spacing: 0) {
+                failIcon.padding(.trailing, 22)
+                Text("Error occur when signing in, Please try again").fontWeight(.bold)
+                Spacer()
+            }
+            .padding(.leading, 39)
+            HStack {
+                Spacer()
+                authorizeButton.padding(.trailing, 33)
+            }
+            Spacer()
+        }
+    }
+
+    var failIcon: some View {
+        Text(Image(systemName: "xmark.circle.fill"))
+            .fontWeight(.bold)
+            .foregroundColor(.red)
+            .font(.system(size: 42))
+    }
+}
+
+// MARK: - Preview
+#if DEBUG
+struct AuthorizePopup_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            AuthorizePopup()
+                .injectPreview(AppState(AppState.UserData(userInfo: .notRequested)))
+                .previewDisplayName("Empty User")
+            AuthorizePopup()
+                .injectPreview(AppState(AppState.UserData(userInfo: .isLoading(last: nil))))
+                .previewDisplayName("Loading")
+            AuthorizePopup()
+                .injectPreview(AppState(AppState.UserData(userInfo: .loaded(UserInfo.hojonge))))
+                .previewDisplayName("Loaded")
+            AuthorizePopup()
+                .injectPreview(AppState(AppState.UserData(userInfo: .failed(NSError()))))
+                .previewDisplayName("Fail")
+        }
+    }
+}
+#endif

--- a/LabelLab/LabelLab/UI/Screens/ContentView.swift
+++ b/LabelLab/LabelLab/UI/Screens/ContentView.swift
@@ -26,10 +26,28 @@ struct ContentView: View {
             Image(systemName: "globe")
                 .imageScale(.large)
                 .foregroundColor(.accentColor)
+            Button {
+                appState.routing.rootRouting.isShowingLoginPopup = true
+            } label: {
+                Text("팝업 띄우기")
+            }
+        }
+        .sheet(isPresented: $appState.routing.rootRouting.isShowingLoginPopup) {
+            AuthorizePopup()
         }
     }
 }
 
+// MARK: - Routing
+extension ContentView {
+
+    struct Routing: Equatable {
+        var isShowingLoginPopup: Bool = false
+    }
+
+}
+
+// MARK: - Preview
 #if DEBUG
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {

--- a/LabelLab/LabelLab/UI/Screens/ContentView.swift
+++ b/LabelLab/LabelLab/UI/Screens/ContentView.swift
@@ -35,6 +35,7 @@ struct ContentView: View {
         .sheet(isPresented: $appState.routing.rootRouting.isShowingLoginPopup) {
             AuthorizePopup()
         }
+        // TODO: Frame minimum size 지정필요
     }
 }
 

--- a/LabelLab/LabelLab/Utilities/Color.swift
+++ b/LabelLab/LabelLab/Utilities/Color.swift
@@ -9,7 +9,9 @@ import SwiftUI
 
 // MARK: - Color Assests
 extension Color {
-
+    // TODO: Hex 값 초기화 대신 Assests 에 추가해야함
+    static let statusBackground: Color = Color("1E1E1E")
+    static let statusTitle: Color = Color("EBEBF5").opacity(0.6)
 }
 
 // MARK: - Hex Color initializer


### PR DESCRIPTION
# Issue Number
🔒 Close #4 

## New features

- Authorize Popup UI

|인증 정보가 없을 때|액세스 토큰을 요청 중일 때|성공적으로 인증했을 때|인증하다가 에러 뜸|
|:---:|:---:|:---:|:---:|
|<img width="466" alt="image" src="https://user-images.githubusercontent.com/57793298/186554450-37ec5921-eaf6-4aa2-bb5b-90b05fb00536.png">|<img width="471" alt="image" src="https://user-images.githubusercontent.com/57793298/186554475-6ee6bc04-c4ad-4105-8917-64a1476fd5c4.png">|<img width="457" alt="image" src="https://user-images.githubusercontent.com/57793298/186554491-ca0e20ee-360f-4806-a46a-26f084ac7cdb.png">|<img width="461" alt="image" src="https://user-images.githubusercontent.com/57793298/186554524-d438b88c-88a2-4482-9d19-c50c35d05a70.png">|

- Content View 의 Routing 을 통해 Authorize Popup 을 띄운다.
- Mac os 기본 닫기 버튼 스타일의 DismissButton 추가
<img width="23" alt="image" src="https://user-images.githubusercontent.com/57793298/186554835-7857f65f-1998-4767-b245-4dda68a922b5.png">


## Review points

- [Dismiss Button 추가](https://github.com/HoJongE/LabelLab/blob/19ac02ec8f9666bf16990af129dba3e920e97470/LabelLab/LabelLab/UI/Components/DismissButton.swift#L10-L17)
- Loadable enum 으로 UserInfo (인증 정보) 를 관리함 
- [Loadable enum case 에 따라 UI 를 구성함](https://github.com/HoJongE/LabelLab/compare/feature/%234_authorization_ui?expand=1#diff-fe3dccee5a29d6313ecc4339a5881307d5f63ee27284296ec12372bae86fed1dR74-R88)
- [ContentView 의 Routing 으로 Authroize popup 을 띄운다.](https://github.com/HoJongE/LabelLab/compare/feature/%234_authorization_ui?expand=1#diff-98a02547768c6139936be7226a66e1817fb179df5675026407e9d075fc74e5caR42-R48)

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
