### PR TITLE
Feature/firebase signing in

### DIFF
--- a/LabelLab/.swiftlint.yml
+++ b/LabelLab/.swiftlint.yml
@@ -4,7 +4,8 @@ excluded:
 - LabelLab/Models/MockData.swift
 
 line_length:
-  warning: 200
+  warning: 240
+  error: 300
   ignores_function_declarations: true
   ignores_comments: true
   ignores_interpolated_strings: true

--- a/LabelLab/LabelLab/Interactors/OAuthInteractor.swift
+++ b/LabelLab/LabelLab/Interactors/OAuthInteractor.swift
@@ -32,7 +32,7 @@ extension RealOAuthInteractor: OAuthInteractor {
         oAuthService.openOAuthSite()
     }
 
-    func requestAccessToken(with authorizeCode: String) async {
+    @MainActor func requestAccessToken(with authorizeCode: String) async {
         do {
             let serviceName = try getServiceName()
             let accessToken: AccessToken = try await oAuthService.requestAccessToken(with: authorizeCode)
@@ -44,8 +44,7 @@ extension RealOAuthInteractor: OAuthInteractor {
         }
     }
 
-    // TODO: Firebase 인증 후 UserInfo 요청해야함!
-    func requestUserInfo() async {
+    @MainActor func requestUserInfo() async {
         do {
             let serviceName = try getServiceName()
             guard let token = try await PasswordKeychainManager(service: serviceName).getPassword(for: KeychainConst.accessToken) else {
@@ -59,7 +58,7 @@ extension RealOAuthInteractor: OAuthInteractor {
         }
     }
 
-    func logout() async {
+    @MainActor func logout() async {
         do {
             let serviceName = try getServiceName()
             try await PasswordKeychainManager(service: serviceName)

--- a/LabelLab/LabelLab/Interactors/OAuthInteractor.swift
+++ b/LabelLab/LabelLab/Interactors/OAuthInteractor.swift
@@ -47,7 +47,12 @@ extension RealOAuthInteractor: OAuthInteractor {
     // TODO: Firebase 인증 후 UserInfo 요청해야함!
     func requestUserInfo() async {
         do {
-            let userInfo: UserInfo = try await oAuthService.requestUserInfo()
+            let serviceName = try getServiceName()
+            guard let token = try await PasswordKeychainManager(service: serviceName).getPassword(for: KeychainConst.accessToken) else {
+                appState.userData.userInfo = .failed(OAuthError.tokenNotExist)
+                return
+            }
+            let userInfo: UserInfo = try await oAuthService.requestUserInfo(with: token)
             appState.userData.userInfo = .loaded(userInfo)
         } catch {
             appState.userData.userInfo = .failed(error)

--- a/LabelLab/LabelLab/Models/MockData.swift
+++ b/LabelLab/LabelLab/Models/MockData.swift
@@ -25,10 +25,10 @@ extension Template {
 }
 
 extension UserInfo {
-    static let woody: UserInfo = UserInfo(id: "Woody", nickname: "우디", profileImage: "https://avatars.githubusercontent.com/u/56102421?v=4", email: "woody@gmail.com")
+    static let woody: UserInfo = UserInfo(id: 1, nickname: "우디", profileImage: "https://avatars.githubusercontent.com/u/56102421?v=4", email: "woody@gmail.com")
 
-    static let hojonge: UserInfo = UserInfo(id: "HoJongPARK", nickname: "호종이", profileImage: "https://avatars.githubusercontent.com/u/57793298?s=400&u=c605ccc99eb0f6c7a2e4ac4f59c22b316532f2b8&v=4", email: "pjh00098@gmail.com")
-    static let avery: UserInfo = UserInfo(id: "Avery", nickname: "에이버리", profileImage: nil, email: "avery@pos.idserve.com")
+    static let hojonge: UserInfo = UserInfo(id: 2, nickname: "호종이", profileImage: "https://avatars.githubusercontent.com/u/57793298?s=400&u=c605ccc99eb0f6c7a2e4ac4f59c22b316532f2b8&v=4", email: "pjh00098@gmail.com")
+    static let avery: UserInfo = UserInfo(id: 3, nickname: "에이버리", profileImage: nil, email: "avery@pos.idserve.com")
 }
 
 extension Label {

--- a/LabelLab/LabelLab/Models/UserInfo.swift
+++ b/LabelLab/LabelLab/Models/UserInfo.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// 유저 닉네임, 유저 프로필, 유저 이메일 등 추가 정보
 struct UserInfo: Codable, Identifiable {
-    var id: String // 유저 id
+    var id: Int // 유저 id
     var nickname: String // 닉네임
     var profileImage: String? // 프로필 이미지 url
     var email: String // 이메일
@@ -17,7 +17,7 @@ struct UserInfo: Codable, Identifiable {
 
 extension UserInfo: Equatable {
     static func == (lhs: UserInfo, rhs: UserInfo) -> Bool {
-        lhs.id == rhs.id
+        lhs.id == rhs.id && lhs.nickname == rhs.nickname && lhs.profileImage == rhs.profileImage && lhs.email == rhs.email
     }
 }
 

--- a/LabelLab/LabelLab/Service/API/APICall.swift
+++ b/LabelLab/LabelLab/Service/API/APICall.swift
@@ -38,7 +38,7 @@ extension APICall {
         var request = URLRequest(url: url)
         request.httpMethod = method
         _ = headers.map { (key, value) in
-            request.addValue(key, forHTTPHeaderField: value)
+            request.addValue(value, forHTTPHeaderField: key)
         }
         return try await session.data(for: request)
     }

--- a/LabelLab/LabelLab/Service/API/GithubAPI.swift
+++ b/LabelLab/LabelLab/Service/API/GithubAPI.swift
@@ -8,6 +8,7 @@
 enum GithubAPI {
     case authorize
     case accessToken(authorizeCode: String)
+    case getUser(accessToken: String)
 }
 
 extension GithubAPI: APICall {
@@ -18,6 +19,8 @@ extension GithubAPI: APICall {
             return URLCollection.Github.GITHUB_AUTHORIZE
         case .accessToken:
             return URLCollection.Github.GITHUB_ACCESS_TOKEN
+        case .getUser:
+            return URLCollection.Github.GITHUB_GET_AUTHETICATED_USER
         }
     }
 
@@ -25,6 +28,7 @@ extension GithubAPI: APICall {
         switch self {
         case .authorize: return "get"
         case .accessToken: return "post"
+        case .getUser: return "get"
         }
     }
 
@@ -34,6 +38,11 @@ extension GithubAPI: APICall {
             return [:]
         case .accessToken:
             return ["Accept": "application/json"]
+        case .getUser(accessToken: let token):
+            return [
+                "Accept": "application/vnd.github+json",
+                "Authorization": "Bearer \(token)"
+            ]
         }
     }
 
@@ -46,6 +55,8 @@ extension GithubAPI: APICall {
             return ["code": code,
                     "client_id": KeyStorage.GithubClientId,
                     "client_secret": KeyStorage.GithubClientSecret]
+        case .getUser:
+            return [:]
         }
     }
 
@@ -55,6 +66,8 @@ extension GithubAPI: APICall {
             return URLCollection.Github.GITHUB_AUTHENTICATE_BASE_URL
         case .accessToken:
             return URLCollection.Github.GITHUB_AUTHENTICATE_BASE_URL
+        case .getUser:
+            return URLCollection.Github.GITHUB_API_BASE_URL
         }
     }
 

--- a/LabelLab/LabelLab/Service/OAuthService.swift
+++ b/LabelLab/LabelLab/Service/OAuthService.swift
@@ -9,12 +9,13 @@ import FirebaseAuth
 
 typealias AccessToken = String
 
-enum OAuthServiceError: Error {
+enum OAuthError: Error {
     case dataNotExist
     case tokenNotExist
+    case userInfoNotExist
 }
 
-extension OAuthServiceError: LocalizedError {
+extension OAuthError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
@@ -22,6 +23,8 @@ extension OAuthServiceError: LocalizedError {
             return "에러가 발생했습니다."
         case .tokenNotExist:
             return "액세스 토큰을 발급받지 못했습니다."
+        case .userInfoNotExist:
+            return "유저 정보가 없습니다."
         }
     }
     var recoverySuggestion: String? {
@@ -30,6 +33,8 @@ extension OAuthServiceError: LocalizedError {
             return "다시 요청해주세요."
         case .tokenNotExist:
             return "다시 요청해주세요."
+        case .userInfoNotExist:
+            return "다시 로그인을 시도해주세요."
         }
     }
 }
@@ -38,7 +43,7 @@ protocol OAuthService {
     var session: URLSessionProtocol { get }
     func openOAuthSite()
     func requestAccessToken(with code: String) async throws -> AccessToken
-    func requestUserInfo() async throws -> UserInfo
+    func requestUserInfo(with token: String) async throws -> UserInfo
     func logout() async throws
 
 }
@@ -46,6 +51,7 @@ protocol OAuthService {
 final class GithubOAuthService {
     static let shared: GithubOAuthService = .init()
     let session: URLSessionProtocol
+    private let auth: Auth = Auth.auth()
 
     init(_ session: URLSessionProtocol = URLSession.shared) {
         self.session = session
@@ -72,12 +78,21 @@ extension GithubOAuthService {
         return token
     }
 
-    func requestUserInfo() async throws -> UserInfo {
-        return UserInfo.hojonge
+    func requestUserInfo(with token: String) async throws -> UserInfo {
+        // 먼저 Firebase Auth 에 인증되있지 않다면, Github accessToken 으로 인증을 시도함
+        if !ProcessInfo().isRunningTests {
+            if auth.currentUser == nil {
+                let githubAuthProvider = GitHubAuthProvider.credential(withToken: token)
+                try await auth.signIn(with: githubAuthProvider)
+            }
+        }
+        // 인증을 완료했으면, Access Token 으로 Github User Info 를 불러온다.
+        let (data, _) = try await GithubAPI.getUser(accessToken: token).request(with: session)
+        return try parseDataToUserInfo(data)
     }
 
     func logout() async throws {
-        try Auth.auth().signOut()
+        try auth.signOut()
     }
 
 }
@@ -85,9 +100,19 @@ extension GithubOAuthService {
 private extension GithubOAuthService {
 
     func parseDataToAccessToken(_ data: Data) throws -> String {
-        guard let json = try? JSONDecoder().decode([String: String].self, from: data) else { throw OAuthServiceError.dataNotExist }
-        guard let token = json["access_token"] else { throw OAuthServiceError.tokenNotExist }
+        guard let json = try? JSONDecoder().decode([String: String].self, from: data) else { throw OAuthError.dataNotExist }
+        guard let token = json["access_token"] else { throw OAuthError.tokenNotExist }
         return String(token)
+    }
+
+    func parseDataToUserInfo(_ data: Data) throws -> UserInfo {
+        guard let jsonDictionary = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+            throw OAuthError.dataNotExist
+        }
+        guard let id = jsonDictionary["id"] as? Int, let profileImage = jsonDictionary["avatar_url"] as? String, let nickname = jsonDictionary["login"] as? String, let email = jsonDictionary["email"] as? String else {
+            throw OAuthError.userInfoNotExist
+        }
+        return UserInfo(id: id, nickname: nickname, profileImage: profileImage, email: email)
     }
 
 }

--- a/LabelLab/LabelLab/System/LabelLabApp.swift
+++ b/LabelLab/LabelLab/System/LabelLabApp.swift
@@ -16,13 +16,13 @@ struct LabelLabApp: App {
     private let deepLinkHandler: DeepLinkHandler
 
     init() {
+        FirebaseApp.configure()
         let appState = AppState()
         self.diContainer = DIContainer(interactors: .init(
             oAuthInteractor: RealOAuthInteractor(appState: appState)
         ))
         self.deepLinkHandler = RealDeepLinkHandler(diContainer, appState)
         self._appState = StateObject(wrappedValue: appState)
-        FirebaseApp.configure()
     }
 
     var body: some Scene {

--- a/LabelLab/LabelLab/System/LabelLabApp.swift
+++ b/LabelLab/LabelLab/System/LabelLabApp.swift
@@ -28,10 +28,12 @@ struct LabelLabApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .handleAuthEvent()
+                .handleDeepLink(with: deepLinkHandler)
                 .inject(diContainer)
                 .inject(appState)
-                .handleDeepLink(with: deepLinkHandler)
         }
+        .disableNewWindow()
     }
 }
 
@@ -48,4 +50,16 @@ private extension View {
         }
     }
 
+    func handleAuthEvent() -> some View {
+        handlesExternalEvents(preferring: ["*"], allowing: ["*"])
+    }
+}
+
+// MARK: - WindowGroup Extension
+private extension WindowGroup {
+    func disableNewWindow() -> some Scene {
+        commands {
+            CommandGroup(replacing: .newItem, addition: { })
+        }
+    }
 }

--- a/LabelLab/LabelLab/UI/Screens/Authorize/AuthorizePopup.swift
+++ b/LabelLab/LabelLab/UI/Screens/Authorize/AuthorizePopup.swift
@@ -65,7 +65,7 @@ private extension AuthorizePopup {
 // MARK: - Side Effects
 private extension AuthorizePopup {
     func authorizeGithub() {
-        // TODO: Interacts with Interactor
+        diContainer.interactors.oAuthInteractor.openOAuthSite()
     }
 }
 

--- a/LabelLab/LabelLab/Utilities/URLCollection.swift
+++ b/LabelLab/LabelLab/Utilities/URLCollection.swift
@@ -10,6 +10,8 @@ enum URLCollection {
         static let GITHUB_AUTHENTICATE_BASE_URL: String = "https://github.com/login"
         static let GITHUB_AUTHORIZE: String = "/oauth/authorize"
         static let GITHUB_ACCESS_TOKEN: String = "/oauth/access_token"
+        static let GITHUB_API_BASE_URL: String = "https://api.github.com/"
+        static let GITHUB_GET_AUTHETICATED_USER: String = "user"
     }
 }
 

--- a/LabelLab/LabelLabTests/Interactors/OAuthInteractorTests.swift
+++ b/LabelLab/LabelLabTests/Interactors/OAuthInteractorTests.swift
@@ -44,8 +44,9 @@ final class OAuthInteractorTests: XCTestCase {
         XCTAssertEqual(accessToken, ConstantData.accessToken)
     }
 
-    func testRequestUserInfo() async {
+    func testRequestUserInfo() async throws {
         XCTAssertEqual(appState.userData.userInfo, Loadable<UserInfo>.notRequested)
+        try await keychainManager.savePassword("", for: KeychainConst.accessToken)
         await oAuthInteractor.requestUserInfo()
         XCTAssertEqual(appState.userData.userInfo, Loadable<UserInfo>.loaded(UserInfo.hojonge))
     }

--- a/LabelLab/LabelLabTests/Mock/MockedService.swift
+++ b/LabelLab/LabelLabTests/Mock/MockedService.swift
@@ -22,7 +22,7 @@ final class MockOAuthService: OAuthService {
         ConstantData.accessToken
     }
 
-    func requestUserInfo() async throws -> LabelLab.UserInfo {
+    func requestUserInfo(with token: String) async throws -> LabelLab.UserInfo {
         UserInfo.hojonge
     }
 

--- a/LabelLab/LabelLabTests/Service/OAuthAuthenticatorTest.swift
+++ b/LabelLab/LabelLabTests/Service/OAuthAuthenticatorTest.swift
@@ -47,9 +47,9 @@ final class OAuthAuthenticatorTest: XCTestCase {
             XCTFail("Should not pass test because data is empty")
         } catch {
             // then
-            XCTAssertEqual(OAuthServiceError.dataNotExist.recoverySuggestion, (error as? OAuthServiceError)?.recoverySuggestion)
-            XCTAssertEqual(OAuthServiceError.dataNotExist.errorDescription, (error as? OAuthServiceError)?.errorDescription)
-            XCTAssertEqual(OAuthServiceError.dataNotExist, error as? OAuthServiceError)
+            XCTAssertEqual(OAuthError.dataNotExist.recoverySuggestion, (error as? OAuthError)?.recoverySuggestion)
+            XCTAssertEqual(OAuthError.dataNotExist.errorDescription, (error as? OAuthError)?.errorDescription)
+            XCTAssertEqual(OAuthError.dataNotExist, error as? OAuthError)
         }
     }
 
@@ -70,19 +70,21 @@ final class OAuthAuthenticatorTest: XCTestCase {
             XCTFail("Should not pass test because data is malformed")
         } catch {
             // then
-            XCTAssertEqual(OAuthServiceError.tokenNotExist.recoverySuggestion, (error as? OAuthServiceError)?.recoverySuggestion)
-            XCTAssertEqual(OAuthServiceError.tokenNotExist.errorDescription, (error as? OAuthServiceError)?.errorDescription)
-            XCTAssertEqual(OAuthServiceError.tokenNotExist, error as? OAuthServiceError)
+            XCTAssertEqual(OAuthError.tokenNotExist.recoverySuggestion, (error as? OAuthError)?.recoverySuggestion)
+            XCTAssertEqual(OAuthError.tokenNotExist.errorDescription, (error as? OAuthError)?.errorDescription)
+            XCTAssertEqual(OAuthError.tokenNotExist, error as? OAuthError)
         }
     }
 
     func testRequestUserInfo() async throws {
         // given
         var userInfo: UserInfo?
+        let mockURLSession = MockURLSession(data: GithubAPI.githubUserInfo, response: URLResponse())
+        oAuthService = GithubOAuthService(mockURLSession)
         // when
-        userInfo = try await oAuthService.requestUserInfo()
+        userInfo = try await oAuthService.requestUserInfo(with: "")
         // then
-        XCTAssertNotNil(userInfo)
+        XCTAssertEqual(UserInfo(id: 1, nickname: "octocat", profileImage: "https://github.com/images/error/octocat_happy.gif", email: "octocat@github.com"), userInfo)
     }
 
 }

--- a/LabelLab/LabelLabTests/TestHelpers/MockURLData.swift
+++ b/LabelLab/LabelLabTests/TestHelpers/MockURLData.swift
@@ -19,4 +19,54 @@ extension GithubAPI {
         }
         """.utf8)
     }
+    static var githubUserInfo: Data {
+        Data("""
+        {
+          "login": "octocat",
+          "id": 1,
+          "node_id": "MDQ6VXNlcjE=",
+          "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/octocat",
+          "html_url": "https://github.com/octocat",
+          "followers_url": "https://api.github.com/users/octocat/followers",
+          "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+          "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+          "organizations_url": "https://api.github.com/users/octocat/orgs",
+          "repos_url": "https://api.github.com/users/octocat/repos",
+          "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/octocat/received_events",
+          "type": "User",
+          "site_admin": false,
+          "name": "monalisa octocat",
+          "company": "GitHub",
+          "blog": "https://github.com/blog",
+          "location": "San Francisco",
+          "email": "octocat@github.com",
+          "hireable": false,
+          "bio": "There once was...",
+          "twitter_username": "monatheoctocat",
+          "public_repos": 2,
+          "public_gists": 1,
+          "followers": 20,
+          "following": 0,
+          "created_at": "2008-01-14T04:33:35Z",
+          "updated_at": "2008-01-14T04:33:35Z",
+          "private_gists": 81,
+          "total_private_repos": 100,
+          "owned_private_repos": 100,
+          "disk_usage": 10000,
+          "collaborators": 8,
+          "two_factor_authentication": true,
+          "plan": {
+            "name": "Medium",
+            "space": 400,
+            "private_repos": 20,
+            "collaborators": 0
+          }
+        }
+        """.utf8)
+    }
 }


### PR DESCRIPTION
# Issue Number
🔒 Close #5 
🔒 Close #6 
 
## New features

<img width="890" alt="image" src="https://user-images.githubusercontent.com/57793298/188252482-c2ad027b-2486-4df0-b070-6800687254bb.png">

- Github Access Token 을 이용한 Firebase Auth 가입 구현
- 회원가입 과정에 따라, 적절한 UI state 로 업데이트 하는 것을 확인함
- Github API 를 이용해 현재 내 github 계정의 유저 정보를 얻어옴

## Review points

- [@MainActor 를 이용해 await suspension point 에서 다시 resume 될 때, Main thread 에서 작업을 재개](https://github.com/HoJongE/LabelLab/compare/develop...HoJongE:feature%2Ffirebase_signing_in?expand=1#diff-2ceff5eb28b8c9c2c9e8fe1e204893be58d558f17169f8a4cd4ee6b742a39defR35-R61)
- [deep link 와 같은 external events 들을 현재 활성된 window 에서 처리하도록 하는 코드 (원래는 deeplink 가 들어오면 새로운 윈도우를 열어서 처리한다고 하네요)](https://github.com/HoJongE/LabelLab/compare/develop...HoJongE:feature%2Ffirebase_signing_in?expand=1#diff-5cc03d6dbef118050a3808f36bf9deee5375394bbc2e95f833203fb4babc1466R53-R55)

## Questions

- async await 를 아직 몰라서 그러는데, await 로 suspend 하고 원래 실행하던 스레드와 다른 스레드에서 resume 된다고 합니다. 그래서 appState 를 업데이트 하는 코드가 자꾸 워닝이 떴는데 ( 자꾸 background thread 에서 ui 를 업데이트 한다고 함) 그래서 appState 를 변경하는 함수에 @MainActor 를 붙여서 해결했습니다. 검색하기로는 @MainActor 가 붙으면 항상 suspension point 에서 resume 할 때 MainThread 에서 resume 한다고 하는데 정확한 해결책인지는 모르겠네요

## References

[Main Actor - Using Main Actor 부분](https://www.raywenderlich.com/books/modern-concurrency-in-swift/v1.0/chapters/2-getting-started-with-async-await)

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
